### PR TITLE
fix(helm-template): Enable custom cluster issuer input

### DIFF
--- a/helm/kubocd-wh/templates/certificates.yaml
+++ b/helm/kubocd-wh/templates/certificates.yaml
@@ -38,7 +38,7 @@ spec:
     name: {{ include "kubocd.webhook.certificateSelfSignedIssuerName" . }}
 {{- else }}
     kind: ClusterIssuer
-    name: .Values.webhook.certificateClusterIssuer
+    name: {{ .Values.webhook.certificateClusterIssuer }}
 {{- end }}
   secretName: {{ include "kubocd.webhook.secretName" . }}
 
@@ -85,7 +85,7 @@ spec:
     name: {{ include "kubocd.webhook.metrics.certificateSelfSignedIssuerName" . }}
 {{- else }}
     kind: ClusterIssuer
-    name: .Values.metrics.certificateClusterIssuer
+    name: {{ .Values.metrics.certificateClusterIssuer }}
 {{- end }}
   secretName: {{ include "kubocd.webhook.metrics.secretName" . }}
 

--- a/helm/kubocd-wh/templates/certificates.yaml
+++ b/helm/kubocd-wh/templates/certificates.yaml
@@ -38,7 +38,7 @@ spec:
     name: {{ include "kubocd.webhook.certificateSelfSignedIssuerName" . }}
 {{- else }}
     kind: ClusterIssuer
-    name: {{ .Values.webhook.certificateClusterIssuer }}
+    name: .Values.webhook.certificateClusterIssuer
 {{- end }}
   secretName: {{ include "kubocd.webhook.secretName" . }}
 
@@ -85,7 +85,7 @@ spec:
     name: {{ include "kubocd.webhook.metrics.certificateSelfSignedIssuerName" . }}
 {{- else }}
     kind: ClusterIssuer
-    name: {{ .Values.metrics.certificateClusterIssuer }}
+    name: {{ .Values.webhook.metrics.certificateClusterIssuer }}
 {{- end }}
   secretName: {{ include "kubocd.webhook.metrics.secretName" . }}
 

--- a/helm/kubocd-wh/templates/certificates.yaml
+++ b/helm/kubocd-wh/templates/certificates.yaml
@@ -38,7 +38,7 @@ spec:
     name: {{ include "kubocd.webhook.certificateSelfSignedIssuerName" . }}
 {{- else }}
     kind: ClusterIssuer
-    name: .Values.webhook.certificateClusterIssuer
+    name: {{ .Values.webhook.certificateClusterIssuer }}
 {{- end }}
   secretName: {{ include "kubocd.webhook.secretName" . }}
 


### PR DESCRIPTION
Issue with variable assignment in the Helm certificate.yaml template file preventing the correct value from being set for the certificateClusterIssuer variable.