### PR TITLE
chore(dev): dev-environment follow-ups (#8) + dev-up kubeconfig idempotency fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,7 +85,23 @@ RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
     && chmod +x /usr/local/bin/kustomize \
     && rm -rf "kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz" checksums.txt
 
-# 6. Install Node.js and verify official SHA256 checksum
+# 6. Install k9s and verify official SHA256 checksum
+# checksums.sha256 covers all platforms; we extract the matching line (same pattern as Flux).
+RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
+    K9S_VERSION=$(awk '/^k9s/ {print $2}' /tmp/.tool-versions) \
+    && ARCH=$(dpkg --print-architecture) \
+    && cd /tmp \
+    && curl -fsSL -O "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz" \
+    && curl -fsSL -O "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/checksums.sha256" \
+    && EXPECTED_SHA=$(grep "  k9s_Linux_${ARCH}.tar.gz$" checksums.sha256) \
+    && [ -n "$EXPECTED_SHA" ] \
+    && echo "$EXPECTED_SHA" | sha256sum -c - \
+    && tar -xzf "k9s_Linux_${ARCH}.tar.gz" k9s \
+    && mv k9s /usr/local/bin/k9s \
+    && chmod +x /usr/local/bin/k9s \
+    && rm -rf "k9s_Linux_${ARCH}.tar.gz" checksums.sha256
+
+# 7. Install Node.js and verify official SHA256 checksum
 # Tarball install (not the base image's nvm) so node/npm/npx land in /usr/local/bin,
 # on PATH for every user including root. Required by Prettier (Markdown formatting).
 RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
@@ -103,14 +119,14 @@ RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
     && rm -rf "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz" SHASUMS256.txt \
     && node --version && npm --version
 
-# 7. Install Prettier globally (used by the pre-commit Markdown hook)
+# 8. Install Prettier globally (used by the pre-commit Markdown hook)
 RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
     PRETTIER_VERSION=$(awk '/^prettier/ {print $2}' /tmp/.tool-versions) \
     && npm install -g "prettier@${PRETTIER_VERSION}" \
     && npm cache clean --force \
     && prettier --version
 
-# 8. Install pre-commit in an isolated virtualenv (avoids PEP 668 system-package conflicts)
+# 9. Install pre-commit in an isolated virtualenv (avoids PEP 668 system-package conflicts)
 RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
     PRECOMMIT_VERSION=$(awk '/^pre-commit/ {print $2}' /tmp/.tool-versions) \
     && apt-get update && apt-get install -y --no-install-recommends python3-venv \
@@ -120,7 +136,7 @@ RUN --mount=type=bind,source=.tool-versions,target=/tmp/.tool-versions \
     && ln -sf /opt/precommit/bin/pre-commit /usr/local/bin/pre-commit \
     && pre-commit --version
 
-# 9. Pre-cache envtest assets in /usr/local/share/envtest
+# 10. Pre-cache envtest assets in /usr/local/share/envtest
 # Pinned to a SHA on the release-0.23 branch (Go 1.25-compatible); published
 # v0.24.x tags require Go 1.26. To bump:
 #   git ls-remote https://github.com/kubernetes-sigs/controller-runtime release-0.23

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,23 +30,17 @@ Persistent named Docker volumes cache Go modules and build output:
 
 ## Pre-cached Tools & Verification
 
-All versions are pinned to `.tool-versions` as the single source of truth.
-kubectl, Helm, Kind, Flux, Kustomize and Node.js are downloaded and verified
-against their official SHA256 checksums at build time; Go comes from the base
-image, and Prettier/pre-commit are version-pinned npm/pip installs.
+All tool versions are pinned in [`.tool-versions`](../.tool-versions) as the
+single source of truth — see that file for the exact versions. At build time:
 
-- `golang 1.25.x` — from the base image (`go:dev-1.25-bookworm`); the patch
-  floats to the latest 1.25 release, frozen at runtime by `GOTOOLCHAIN=local`
-- `kubectl 1.34.0`
-- `helm 3.16.2`
-- `kind 0.31.0`
-- `flux 2.8.8`
-- `kustomize 5.8.1`
-- `nodejs 24.16.0` (runtime for Prettier)
-- `prettier 3.8.3` (npm; Markdown wrapping via the pre-commit hook)
-- `pre-commit 4.6.0` (pip)
-- `setup-envtest` (pinned to commit `f9589b9f` on the `release-0.23` branch for
-  Go 1.25 compatibility; published v0.24.x tags require Go 1.26)
+- **kubectl, Helm, Kind, Flux, Kustomize, k9s and Node.js** are downloaded and
+  verified against their official SHA256 checksums.
+- **Go** comes from the base image (`go:dev-1.25-bookworm`); its patch floats to
+  the latest 1.25 release, frozen at runtime by `GOTOOLCHAIN=local`.
+- **Prettier** (npm) and **pre-commit** (pip) are version-pinned installs.
+- **setup-envtest** assets are pre-cached, pinned to a commit on the
+  `release-0.23` branch for Go 1.25 compatibility (published v0.24.x tags
+  require Go 1.26).
 
 The Kind apiserver is reachable from inside the devcontainer via
 `host.docker.internal` — the kubeconfig is patched at `make dev-up` time (Docker

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,6 +4,7 @@ helm 3.16.2
 kind 0.31.0
 flux 2.8.8
 kustomize 5.8.1
+k9s 0.50.18
 nodejs 24.16.0
 prettier 3.8.3
 pre-commit 4.6.0

--- a/dev.env.example
+++ b/dev.env.example
@@ -12,3 +12,7 @@
 # 5001 is already in use on your machine. NOTE: if the registry is already
 # running, run `make dev-down` before `make dev-up` for the new port to apply.
 #KUBOCD_REGISTRY_PORT=5001
+
+# Image registry used by `make docker-build` and the publish targets (default:
+# quay.io/kubocd). Override to build and push dev images under your own namespace.
+#REGISTRY=ghcr.io/your-user

--- a/hack/check-tools.sh
+++ b/hack/check-tools.sh
@@ -1,56 +1,57 @@
 #!/usr/bin/env bash
-# Check that locally installed dev tools match the versions pinned in
-# .tool-versions. Prints a per-tool report and exits non-zero if any tool is
-# missing or mismatched. No 'set -e': probing absent tools is expected.
+# Check locally installed dev tools against the versions pinned in .tool-versions.
+# A tool is reported only when something is off:
+#   - missing          -> error   (script exits non-zero)
+#   - version mismatch -> warning (non-fatal; lower or higher both warn)
+#   - exact match      -> silent
+# No 'set -e': probing absent tools is expected.
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 if [ ! -f "${TOOL_VERSIONS_FILE}" ]; then
-    echo "❌ .tool-versions file not found!"
+    echo "❌ .tool-versions file not found!" >&2
     exit 1
 fi
 
-echo "Checking local development tools against .tool-versions..."
 failed=0
 
-# check_tool <label> <required> <installed>
-check_tool() {
-    local label="$1" req="$2" cur="$3"
-    if [ -z "$cur" ]; then
-        echo "❌ ${label} is NOT installed! (Required: ${req})"
-        return 1
-    elif [ "$req" != "$cur" ]; then
-        echo "❌ ${label} version mismatch! (Required: ${req}, Installed: ${cur})"
-        return 1
+semver() { grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1; }
+minor() { awk -F. '{ print $1"."$2 }'; }
+
+# report <label> <pinned> <installed>
+#   empty <installed> => not installed.
+report() {
+    local label="$1" pinned="$2" installed="$3"
+    [ -z "$pinned" ] && return 0 # not pinned in .tool-versions; nothing to check
+    if [ -z "$installed" ]; then
+        echo "❌ ${label}: not installed (pinned ${pinned})" >&2
+        failed=1
+    elif [ "$pinned" != "$installed" ]; then
+        echo "⚠️  ${label}: ${installed} installed, ${pinned} pinned" >&2
     fi
-    echo "✅ ${label} version matches (${cur})"
-    return 0
+    # exact match -> no output
 }
 
-major_minor() { echo "$1" | awk -F. '{ print $1"."$2 }'; }
-
-# Go: check MAJOR.MINOR only (patch version floats with base image)
-tool_go_full="$(tool_version golang)"
-tool_go_minor="$(major_minor "$tool_go_full")"
-installed_go="$(go version 2>/dev/null | awk '{print $3}' | sed 's/go//')"
-installed_go_minor="$(major_minor "$installed_go")"
-
-if [ -z "$installed_go" ]; then
-    echo "❌ Go is NOT installed! (Required: ${tool_go_minor} from .tool-versions)"
-    failed=1
-elif [ "$tool_go_minor" != "$installed_go_minor" ]; then
-    echo "❌ Go MAJOR.MINOR mismatch! (Required: ${tool_go_minor}, Installed: ${installed_go_minor}; full versions: .tool-versions=${tool_go_full}, installed=${installed_go})"
-    failed=1
-else
-    echo "✅ Go MAJOR.MINOR matches (${tool_go_minor}; full versions: .tool-versions=${tool_go_full}, installed=${installed_go})"
+# Go is special: compare MAJOR.MINOR only (the patch floats with the base image).
+go_minor="$(tool_version golang | minor)"
+go_installed="$(go version 2>/dev/null | awk '{print $3}' | sed 's/go//')"
+if [ -n "$go_minor" ]; then
+    if [ -z "$go_installed" ]; then
+        echo "❌ go: not installed (pinned ${go_minor}.x)" >&2
+        failed=1
+    elif [ "$go_minor" != "$(printf '%s' "$go_installed" | minor)" ]; then
+        echo "⚠️  go: ${go_installed} installed, ${go_minor}.x pinned" >&2
+    fi
 fi
-check_tool "kubectl" "$(tool_version kubectl)" \
-    "$(kubectl version --client 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)" || failed=1
-check_tool "Helm" "$(tool_version helm)" \
-    "$(helm version --template='{{.Version}}' 2>/dev/null | sed 's/^v//')" || failed=1
-check_tool "Kind" "$(tool_version kind)" \
-    "$(kind version 2>/dev/null | awk '{print $2}' | sed 's/^v//')" || failed=1
-check_tool "Flux" "$(tool_version flux)" \
-    "$(flux version --client 2>/dev/null | awk '/flux/ {print $2}' | sed 's/^v//')" || failed=1
+
+report kubectl "$(tool_version kubectl)" "$(kubectl version --client 2>/dev/null | semver)"
+report helm "$(tool_version helm)" "$(helm version --template='{{.Version}}' 2>/dev/null | semver)"
+report kind "$(tool_version kind)" "$(kind version 2>/dev/null | semver)"
+report flux "$(tool_version flux)" "$(flux version --client 2>/dev/null | semver)"
+report kustomize "$(tool_version kustomize)" "$(kustomize version 2>/dev/null | semver)"
+report k9s "$(tool_version k9s)" "$(k9s version 2>/dev/null | semver)"
+report nodejs "$(tool_version nodejs)" "$(node --version 2>/dev/null | semver)"
+report prettier "$(tool_version prettier)" "$(prettier --version 2>/dev/null | semver)"
+report pre-commit "$(tool_version pre-commit)" "$(pre-commit --version 2>/dev/null | semver)"
 
 exit "$failed"

--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -137,6 +137,13 @@ else
   echo "Kind cluster '${cluster_name}' already exists."
 fi
 
+# Refresh the kubeconfig context. 'kind create cluster' writes the 'kind-<name>'
+# context only on creation, so a pre-existing cluster — or a kubeconfig that lost
+# its contexts — would leave nothing for the '--context kind-<name>' flags below
+# to resolve. 'kind export kubeconfig' is idempotent; the patch just after
+# repoints the server to host.docker.internal.
+kind export kubeconfig --name "${cluster_name}"
+
 # Patch kubeconfig: from the devcontainer, the apiserver port is reachable via host.docker.internal,
 # and the cert validates against the SAN '${cluster_name}-control-plane'.
 echo "Patching kubeconfig for devcontainer access..."

--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -151,30 +151,10 @@ if [ "$(docker inspect -f '{{json .NetworkSettings.Networks.kind}}' "${reg_name}
   retry docker network connect "kind" "${reg_name}"
 fi
 
-# 4. Document the local registry hosting inside the cluster
-# This tells tools like Flux/Helm where the OCI registry is located
-echo "Applying local registry hosting ConfigMap to kube-public..."
-# Note: the manifest is materialized to a temp file before being applied via retry.
-# Piping a heredoc directly into 'retry kubectl apply -f -' consumes stdin on the
-# first attempt; subsequent retries would receive empty input and silently no-op.
-cat <<EOF > /tmp/local-registry-hosting.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:${reg_port}"
-    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
-EOF
-retry kubectl apply --context "kind-${cluster_name}" -f /tmp/local-registry-hosting.yaml
-rm -f /tmp/local-registry-hosting.yaml
-
-# 5. Configure containerd on each cluster node to route localhost:5001 to our local registry container
+# 4. Configure containerd on each cluster node to route localhost:${reg_port} to our local registry container
 echo "Configuring containerd registry routing on Kind nodes..."
 for node in $(kind get nodes --name "${cluster_name}"); do
-  # Create standard containerd directory for localhost:5001 certs/routing
+  # Create standard containerd directory for localhost:${reg_port} certs/routing
   docker exec "${node}" mkdir -p "/etc/containerd/certs.d/localhost:${reg_port}"
   
   # Inject the hosts.toml mapping inside the node
@@ -187,7 +167,7 @@ server = "http://${reg_name}:${reg_port}"
 EOF
 done
 
-# 6. Bootstrap Flux inside the Kind cluster
+# 5. Bootstrap Flux inside the Kind cluster
 if ! kubectl --context "kind-${cluster_name}" get namespace flux-system >/dev/null 2>&1; then
   echo "Bootstrapping Flux (system controllers) into the cluster..."
   retry flux install --context "kind-${cluster_name}"
@@ -195,23 +175,7 @@ else
   echo "Flux is already installed in the cluster."
 fi
 
-# 7. Install KuboCD CRDs into the cluster
-echo "Installing KuboCD CRDs into the cluster..."
-# Note: same stdin-consumption rationale as step 4 — materialize the rendered
-# CRDs to a temp file so retries see consistent input on subsequent attempts.
-kustomize build config/crd > /tmp/kubocd-crds.yaml
-retry kubectl --context "kind-${cluster_name}" apply -f /tmp/kubocd-crds.yaml
-rm -f /tmp/kubocd-crds.yaml
-
-# 8. Wait for core resources to be fully ready
-echo "Waiting for KuboCD CRDs to be established..."
-for f in config/crd/bases/*.yaml; do
-  crd_name=$(awk '/^metadata:/ {in_meta=1} /^spec:/ {in_meta=0} in_meta && /^[[:space:]]+name:/ {print $2; exit}' "$f")
-  if [ -n "$crd_name" ]; then
-    kubectl --context "kind-${cluster_name}" wait --for=condition=Established --timeout=60s "crd/${crd_name}"
-  fi
-done
-
+# 6. Wait for Flux controllers to be available
 echo "Waiting for Flux controllers to be available..."
 kubectl --context "kind-${cluster_name}" -n flux-system wait \
   deploy/helm-controller \


### PR DESCRIPTION
## Summary

Follow-up polish on the dev environment (#8), plus a `dev-up` idempotency fix
found along the way.

Implements all of #8:

- **Trim kind bootstrap** — drop the KuboCD CRD install and its "Established"
  wait, and the `local-registry-hosting` ConfigMap (a KEP-1755 discovery hint
  for tools like Tilt/Skaffold, not read by Flux/Helm and referenced nowhere
  else in the repo). Fix stale `localhost:5001` comments.
- **k9s** — added to `.tool-versions` + checksum-verified install in the
  devcontainer.
- **check-tools** — now covers every pinned tool; missing -> error (non-zero
  exit), version mismatch -> warning (non-fatal), exact match -> silent.
- **Docs** — the devcontainer README no longer duplicates pinned versions (it
  points to `.tool-versions`); `dev.env.example` documents the `REGISTRY`
  override.

Plus, outside #8:

- **fix(dev): export kubeconfig in `dev-up`** — `make dev-up` failed with
  `context "kind-kubocd" does not exist` whenever the kind cluster pre-existed
  but the kubeconfig had lost its context (only `kind create` writes it). It now
  runs `kind export kubeconfig` every time, making `dev-up` idempotent.

Closes #8.

## Test plan

- [x] `make dev-down && make dev-up` in the devcontainer -> control-plane Ready,
  Flux 4/4 Available, no KuboCD CRDs (intended), exit 0.
- [x] `check-tools` in the devcontainer -> silent for matching tools,
  `k9s: not installed` + exit 1 when missing (all three paths exercised).
- [x] Idempotency fix: reproduced the broken state (no `kind-kubocd` context,
  cluster up) -> fixed `dev-up` recreated the context and Flux installed, exit 0.
- [x] `REGISTRY` override proven via `make -n docker-build` with `dev.env`.
- [~] k9s install verified by inspection (release URL, checksum format, tarball
  layout mirror the Flux step); not yet exercised by a full image rebuild.